### PR TITLE
Renamed users.email_address to users.email

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,7 +6,7 @@ class PasswordsController < ApplicationController
   end
 
   def create
-    if user = User.find_by(email_address: params[:email_address])
+    if user = User.find_by(email: params[:email])
       PasswordsMailer.reset(user).deliver_later
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.authenticate_by(params.permit(:email_address, :password))
+    if user = User.authenticate_by(params.permit(:email, :password))
       start_new_session_for user
       redirect_to after_authentication_url
     else

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -1,6 +1,6 @@
 class PasswordsMailer < ApplicationMailer
   def reset(user)
     @user = user
-    mail subject: "Reset your password", to: user.email_address
+    mail subject: "Reset your password", to: user.email
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
-  normalizes :email_address, with: ->(e) { e.strip.downcase }
+  normalizes :email, with: ->(e) { e.strip.downcase }
 end

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -3,6 +3,6 @@
 <%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
 <%= form_with url: passwords_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email] %><br>
   <%= form.submit "Email reset instructions" %>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,13 @@
 <%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
 
 <%= form_with url: session_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%= form.email_field :email,
+                       required: true,
+                       autofocus: true,
+                       autocomplete: "username",
+                       placeholder: "Enter your email address",
+                       value: params[:email] %>
+  <br>
   <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>
   <%= form.submit "Sign in" %>
 <% end %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -25,7 +25,7 @@
       <div class="sidebar-auth">
         <% if authenticated? %>
           <div class="user-info">
-            <p class="welcome-text">Welcome, <%= Current.user.email_address %>!</p>
+            <p class="welcome-text">Welcome, <%= Current.user.email %>!</p>
           </div>
           <div class="auth-actions">
             <%= button_to "Sign out", session_path, method: :delete, class: "btn btn-logout" %>

--- a/db/migrate/20250529055234_rename_user_email_address_to_email.rb
+++ b/db/migrate/20250529055234_rename_user_email_address_to_email.rb
@@ -1,0 +1,11 @@
+class RenameUserEmailAddressToEmail < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :users, :email_address, :email
+    rename_index :users, :index_users_on_email_address, :index_users_on_email
+  end
+
+  def down
+    rename_index :users, :index_users_on_email, :index_users_on_email_address
+    rename_column :users, :email, :email_address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_26_040630) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_29_055234) do
   create_table "sessions", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "ip_address"
@@ -21,11 +21,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_26_040630) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email_address", null: false
+    t.string "email", null: false
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "sessions", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,7 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+User.create(email: "admin@example.com",
+            password: "12341234",
+            password_confirmation: "12341234")

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,9 @@
 <% password_digest = BCrypt::Password.create("password") %>
 
 one:
-  email_address: one@example.com
+  email: one@example.com
   password_digest: <%= password_digest %>
 
 two:
-  email_address: two@example.com
+  email: two@example.com
   password_digest: <%= password_digest %>


### PR DESCRIPTION
## Renames user email column from `email_address` to `email`

### Changes
- Renames `users.email_address` column to `users.email` 
- Updated corresponding unique index from `index_users_on_email_address` to `index_users_on_email`
- Migration is fully reversible

### Rationale
Simplifies the column name to follow standard Rails conventions and improves code readability.
